### PR TITLE
Remove key-to-action coupling.

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -27,6 +27,16 @@ export function KeyToNum(key: Enums.Key): number {
     }
 }
 
+/**
+ * isNumber: Check if value is a number, including
+ * the number 0.
+ */
+export function isNumber(val) {
+    console.log('testing val', val);
+    var res = parseInt(val, 10);
+    return isNaN ? null : res;
+} 
+
 export function KeyToChar(key: Enums.Key): string {
     switch (key) {
         case Enums.Key.a:
@@ -43,7 +53,7 @@ export function KeyToChar(key: Enums.Key): string {
             return "f";
         case Enums.Key.g:
             return "g";
-        case Enums.Key.a:
+        case Enums.Key.h:
             return "h";
         case Enums.Key.i:
             return "i";

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -1,0 +1,51 @@
+export default {
+	"normalMode": {
+		"singleAction": {
+			"I": "firstInsertAction",
+			"A": "endAppendAction",
+			"o": "insertLineBelowAction",
+			"O": "insertLineAboveAction",
+			"x": "characterDeleteAction",
+			"X": "characterBeforeDeleteAction",
+			"s": "characterDeleteInsertAction",
+			"S": "lineDeleteInsertAction",
+			"D": "deleteToEndAction",
+			"Y": "yancToEndAction",
+			"C": "deleteInsertToEndAction",
+			"p": "pasteBelowAction",
+			"P": "pasteAboveAction"
+		},
+		"textObjectOrSingleAction": {
+			"i": "insertAction",
+			"a": "appendAction",
+		},
+		"requireMotionAction": {
+			"d": "deleteAction",
+			"y": "yancAction",
+			"c": "changeAction"	
+		},
+		"requireCharMotion": {
+			"f": "find",
+			"t": "till",
+			"F": "findBack",
+			"T": "tillBack"	
+		},
+		"motion": {
+			"l": "RightMotion",
+			"h": "LeftMotion",
+			"j": "DownMotion",
+			"k": "UpMotion",
+			"$": "EndMotion",
+			"w": "ForwardWordMotion",
+			"b": "ForwardWordMotion.SetBack"
+		},
+		"zero": {
+			"0": "FirstMotion"
+		},
+		"numWithoutZero": [
+			1,2,3,4,5,6,7,8,9
+		],
+		
+		
+	}
+}


### PR DESCRIPTION
Extracted all references to "keys" for features, instead calling the keybindings.ts to find the appropriate action. This will hopefully allow us not tie specific keys to actions. With this extracted, I think a nice way to clean this up is to create a VimState. Right now we are using the VimStyle, but just using an enum and switch.

Further, I cleaned up a couple incorrect keybindings.  All of the previous functionality still works. Granted my f and t keys don't currently work, and I'm unsure if they worked previously. I'm attempting to use atoms vim mode as a good guide. https://github.com/atom/vim-mode/blob/master/lib/vim-state.coffee

I'm looking at creating the state machine next, now that I got the flow of your application. The hope is that by making a central state machine, we can pass some of these actions to their own classes, which can interact with the machine. We'll see if the idea works. :P

I can also take a look at the f and t commands. Don't hesitate to break down some features in the issues, and allow me to take them on :).