### PR TITLE
Fixed dj, dk, dw, db. Fixed word motion ignoring new line characters.

### DIFF
--- a/src/VimStyle.ts
+++ b/src/VimStyle.ts
@@ -61,25 +61,39 @@ export class VimStyle implements IVimStyle {
 export class Position implements IPosition {
     public line: number;
     public char: number;
+    
+    public constructor(line?: number, char?: number) {
+        this.line = line || 0;
+        this.char = char || 0;
+    }
+    
+    public IsEqual(position: IPosition) {
+        return this.line === position.line && this.char === position.char;
+    }
 }
 
 export class Range implements IRange {
     public start: IPosition;
     public end: IPosition;
     
+    public constructor(start?: IPosition, end?: IPosition) {
+        this.start = start || null;
+        this.end = end || null;
+        
+        if(this.start && this.end) {
+            this.Sort();
+        }
+    }
+    
     public Sort() {
-        var isReverse = false;
-        if (this.end.line < this.start.line) {
-            isReverse = true;
-        } else if (this.end.line == this.start.line) {
-            if (this.end.char < this.start.char) {
-                isReverse = true;
-            }
+        if(this.start.line < this.end.line || 
+            (this.start.line === this.end.line &&
+            this.start.char <= this.end.char)) {
+                return;
         }
-        if (isReverse) {
-            var b = this.start;
-            this.start = this.end;
-            this.end = b;
-        }
+        
+        var temp = this.start;
+        this.start = this.end;
+        this.end = temp;
     }
 }

--- a/src/action/DeleteAction.ts
+++ b/src/action/DeleteAction.ts
@@ -38,41 +38,38 @@ export class DeleteAction implements IRequireMotionAction {
     }
 
     public Execute(editor: IEditor, vim: IVimStyle) {
-        var r = new Range();
-        r.start = editor.GetCurrentPosition();
-        var p = this.motion.CalculateEnd(editor, r.start);
-        if (p == null) {
-            // cancel
+        var start = editor.GetCurrentPosition();
+        var range = this.motion.CalculateSelectionRange(editor, start);
+        
+        if(!range) {
             return;
         }
-        r.end = p; 
-        r.Sort();
 
         var item = new RegisterItem();
         if (this.isLine) {
 
-            r.start.char = 0;
-            r.end.line = r.end.line + 1;
-            r.end.char = 0;
+            range.start.char = 0;
+            range.end.line = range.end.line + 1;
+            range.end.char = 0;
             var lastLineCount = editor.GetLastLineNum();
-            if (r.end.line > lastLineCount) {
+            if (range.end.line > lastLineCount) {
                 // over last line
                 var lastLine = editor.ReadLine(lastLineCount)
-                r.end.line = lastLineCount;
-                r.end.char = lastLine.length;
-                item.Body = editor.ReadRange(r) + "\n";
-                if (r.start.line > 0) {
+                range.end.line = lastLineCount;
+                range.end.char = lastLine.length;
+                item.Body = editor.ReadRange(range) + "\n";
+                if (range.start.line > 0) {
                     // delete previous \n
-                    var preLine = editor.ReadLine(r.start.line - 1);
-                    r.start.line = r.start.line - 1;
-                    r.start.char = preLine.length;
+                    var preLine = editor.ReadLine(range.start.line - 1);
+                    range.start.line = range.start.line - 1;
+                    range.start.char = preLine.length;
                 }
             } else {
-                item.Body = editor.ReadRange(r);
+                item.Body = editor.ReadRange(range);
             }
             item.Type = RegisterType.LineText;
         } else {
-            item.Body = editor.ReadRange(r);
+            item.Body = editor.ReadRange(range);
             item.Type = RegisterType.Text;
         }
 
@@ -81,9 +78,9 @@ export class DeleteAction implements IRequireMotionAction {
         }
         if (!this.isOnlyYanc) {
             if (this.isLine && this.isInsert) {
-                editor.ReplaceRange(r, "\n");
+                editor.ReplaceRange(range, "\n");
             } else {
-                editor.DeleteRange(r);
+                editor.DeleteRange(range);
             }
         }
 

--- a/src/motion/AbstractMotion.ts
+++ b/src/motion/AbstractMotion.ts
@@ -1,4 +1,4 @@
-export class AbstractMotion implements IMotion {
+export abstract class AbstractMotion implements IMotion {
 
     private count: number;
 
@@ -9,8 +9,8 @@ export class AbstractMotion implements IMotion {
     public SetCount(count: number) {
         this.count = count;
     }
+    
+    public abstract CalculateSelectionRange(editor: IEditor, start: IPosition): IRange;
 
-    public CalculateEnd(editor: IEditor, start: IPosition): IPosition {
-        throw new Error("UnImplemented");
-    }
+    public abstract CalculateEnd(editor: IEditor, start: IPosition): IPosition;
 }

--- a/src/motion/DownMotion.ts
+++ b/src/motion/DownMotion.ts
@@ -1,5 +1,5 @@
 import {AbstractMotion} from "./AbstractMotion"
-import {Position} from "../VimStyle";
+import {Position, Range} from "../VimStyle";
 
 export class DownMotion extends AbstractMotion {
     
@@ -13,26 +13,62 @@ export class DownMotion extends AbstractMotion {
     public SetUpDirection() {
         this.isUpDirection = true;
     }
+    
+    public CalculateSelectionRange(editor: IEditor, start: IPosition): IRange {
+        var newStart = new Position(start.line, 0);
+        
+        var endLineNum = this.CalculateEndLineNum(editor, start, false);
+
+        if(endLineNum === -1) {
+            return null;
+        }
+        
+        var line = editor.ReadLine(endLineNum);
+        
+        var end = new Position(endLineNum, line.length);
+        
+        return new Range(newStart, end);
+    }
 
     public CalculateEnd(editor: IEditor, start: IPosition): IPosition {
         var end = new Position();
         end.char = start.char;
-        if (this.isUpDirection) {
-            end.line = start.line - this.GetCount();
-            if (end.line < 0) {
-                end.line = 0;
-            }
-        } else {
-            end.line = start.line + this.GetCount();
-            var c = editor.GetLastLineNum();
-            if (end.line > c) {
-                end.line = c;
-            }
-        }
+        
+        end.line = this.CalculateEndLineNum(editor, start, true);
+        
         var line = editor.ReadLine(end.line);
+        
         if (end.char > line.length) {
             end.char = line.length;
         }
+        
         return end;
+    }
+    
+    private CalculateEndLineNum(editor: IEditor, start: IPosition, allowOutOfBounds: boolean): number {
+        var endLineNum: number;
+       
+        if(this.isUpDirection) {
+            endLineNum = start.line - this.GetCount();
+        } else {
+            endLineNum = start.line + this.GetCount();
+        }
+        
+        var isOutOfBounds: boolean;
+        var lastLineNum = editor.GetLastLineNum();
+        
+        if(endLineNum < 0) {
+            endLineNum = 0;
+            isOutOfBounds = true;
+        } else if(endLineNum > lastLineNum) {
+            endLineNum = lastLineNum;
+            isOutOfBounds = true;
+        }
+        
+        if(allowOutOfBounds || !isOutOfBounds) {
+            return endLineNum;
+        }
+        
+        return -1;
     }
 }

--- a/src/motion/EndMotion.ts
+++ b/src/motion/EndMotion.ts
@@ -1,13 +1,18 @@
 import {AbstractMotion} from "./AbstractMotion"
-import {Position} from "../VimStyle";
+import {Position, Range} from "../VimStyle";
 
 export class EndMotion extends AbstractMotion{
 	
+	public CalculateSelectionRange(editor: IEditor, start: IPosition): IRange {
+		var start = new Position(start.line, start.char);
+		var end = this.CalculateEnd(editor, start);
+		
+		return new Range(start, end);
+	}
+	
 	public CalculateEnd(editor: IEditor,start: IPosition): IPosition {
 		var line = editor.ReadLineAtCurrentPosition();
-		var end = new Position();
-		end.line = start.line;
-		end.char = line.length;
-		return end;
-	}
+		
+		return new Position(start.line, line.length);
+	}	
 }

--- a/src/motion/FindCharacterMotion.ts
+++ b/src/motion/FindCharacterMotion.ts
@@ -1,5 +1,5 @@
 import {AbstractMotion} from "./AbstractMotion";
-import {Position} from "../VimStyle";
+import {Position, Range} from "../VimStyle";
 
 export class FindCharacterMotion extends AbstractMotion {
 
@@ -19,6 +19,17 @@ export class FindCharacterMotion extends AbstractMotion {
     
     public SetTillOption() {
         this.isTill = true;
+    }
+    
+    public CalculateSelectionRange(editor: IEditor, start: IPosition): IRange {
+        var start = new Position(start.line, start.char);
+        var end = this.CalculateEnd(editor, start);
+        
+        if(!end) {
+            return null;
+        }
+        
+        return new Range(start, end);
     }
     
     public CalculateEnd(editor: IEditor, start: IPosition): IPosition {

--- a/src/motion/HomeMotion.ts
+++ b/src/motion/HomeMotion.ts
@@ -1,12 +1,17 @@
 import {AbstractMotion} from "./AbstractMotion"
-import {Position} from "../VimStyle";
+import {Position, Range} from "../VimStyle";
 
 export class HomeMotion extends AbstractMotion{
 	
+	public CalculateSelectionRange(editor: IEditor, start: IPosition): IRange {
+		var start = new Position(start.line, start.char);
+		var end = this.CalculateEnd(editor, start);
+
+		return new Range(start, end);
+		
+	}
+	
 	public CalculateEnd(editor: IEditor,start: IPosition): IPosition {
-		var end = new Position();
-		end.line = start.line;
-		end.char = 0;
-		return end;
+		return new Position(start.line, 0);
 	}
 }

--- a/src/motion/LineHeadMotion.ts
+++ b/src/motion/LineHeadMotion.ts
@@ -1,6 +1,6 @@
 import {AbstractMotion} from "./AbstractMotion";
 import * as Utils from "../Utils";
-import {Position} from "../VimStyle";
+import {Position, Range} from "../VimStyle";
 
 enum Target {
     Current,
@@ -27,6 +27,13 @@ export class LineHeadMotion extends AbstractMotion {
     }
     public SetCurrentLineOption() {
         this.targetLine = Target.Current;
+    }
+    
+    public CalculateSelectionRange(editor: IEditor, start: IPosition): IRange {
+        var start = new Position(start.line, start.char);
+        var end = this.CalculateEnd(editor, start);
+        
+        return new Range(start, end);
     }
 
     public CalculateEnd(editor: IEditor, start: IPosition): IPosition {

--- a/src/motion/RightMotion.ts
+++ b/src/motion/RightMotion.ts
@@ -1,5 +1,5 @@
 import {AbstractMotion} from "./AbstractMotion"
-import {Position} from "../VimStyle";
+import {Position, Range} from "../VimStyle";
 
 export class RightMotion extends AbstractMotion {
 
@@ -12,6 +12,12 @@ export class RightMotion extends AbstractMotion {
 
     public SetLeftDirection() {
         this.isLeftDirection = true;
+    }
+    
+    public CalculateSelectionRange(editor: IEditor, start: IPosition): IRange {
+       var start = new Position(start.line, start.char);
+       var end = this.CalculateEnd(editor, start);
+       return new Range(start, end);
     }
 
     public CalculateEnd(editor: IEditor, start: IPosition): IPosition {

--- a/typings/vscode-vim.d.ts
+++ b/typings/vscode-vim.d.ts
@@ -42,6 +42,7 @@ interface ICommandFactory {
 
 interface IMotion {
     SetCount(count: number);
+    CalculateSelectionRange(editor: IEditor, start: IPosition): IRange;
     CalculateEnd(editor: IEditor, start: IPosition): IPosition;
 }
 
@@ -62,6 +63,8 @@ interface IRegister {
 interface IPosition {
     line: number;
     char: number;
+    
+    IsEqual(position: IPosition): boolean;
 }
 
 interface IRange {


### PR DESCRIPTION
dj, dk, dw, and db now work as expected.

Fixed word motion ignoring new line characters.

Example:
```js
//   | is the cursor
var a = |5;
var b = 5;
```
Pressing w before resulted in
```js
//   | is the cursor
var a = 5;
var |b = 5;
```
Now it correctly moves forward one word.
```js
//   | is the cursor
var a = 5;
|var b = 5;
```